### PR TITLE
Reorder first part for newer AWS console

### DIFF
--- a/workshop/beanstalk/03-finish-integration.md
+++ b/workshop/beanstalk/03-finish-integration.md
@@ -12,7 +12,7 @@ Now we need to paste the API URL in the Parameter Store read for the frontend.
 
 1. Go to **EC2** under **Compute**.
 2. Click on **Parameter Store** under **SYSTEMS MANAGER SHARED RESOURCES**.
-3. Select the parameter **/prod/frontend/API_URL**.
+3. Select the parameter **/<your-name>/prod/frontend/API_URL**.
 4. Click **Actions**, **Edit Parameter**.
 5. In the value field past the URL for the API. You may need to remove the last `/` so the URL ends in `elasticbeanstalk.com`. If you left the last path separator all the API calls will fail.
 

--- a/workshop/elb-auto-scaling-group/03-finishing-up.md
+++ b/workshop/elb-auto-scaling-group/03-finishing-up.md
@@ -11,7 +11,7 @@ Finally, we need to re-run CodeBuild so the new bundle on S3 points to the DNS o
 2. On left menu select **Load Balancer** under **LOAD BALANCING**.
 3. Copy the DNS name of your load balancer that appears under **Description**.
 4. On left menu, select **Parameter Store**.
-5. Click on `/prod/frontend/API_URL` and on **Actions** select **Edit Parameter**.
+5. Click on `/<your-name>/prod/frontend/API_URL` and on **Actions** select **Edit Parameter**.
 6. As Value put: `http://` + the DNS that you copied 3 steps ago.
 7. Click **Save Parameter**.
 

--- a/workshop/s3-web-ec2-api-rds/01-serve-website-from-s3.md
+++ b/workshop/s3-web-ec2-api-rds/01-serve-website-from-s3.md
@@ -68,11 +68,13 @@ Every application needs to have some configurations that inherently will vary be
 3. In the search bar  up top, search for **Systems Manager** (it's under **Management & Governance**).
 4. On the left menu select **Parameter Store**.
 5. Click **Create Parameter**.
-6. Enter `/prod/codebuild/WEBSITE_BUCKET_NAME` as name and a meaningful description of what the parameter means (ie. "name of the website bucket").
+6. Enter `/<your-name>/prod/codebuild/WEBSITE_BUCKET_NAME` as name and a meaningful description of what the parameter means (ie. "name of the website bucket").
 7. Enter `s3://<your-bucket-name>` as value.
 8. Click create parameter.
 
 Now we can retrieve the bucket name with `aws ssm get-parameter` like we did [here](/buildspec.frontend.yml). Also, we can use [AWS SSM Agent](http://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html) to manage our instances' configuration from the AWS web console.
+
+You should _now_ go to [buildspec.frontend.yml](/buildspec.frontend.yml) and change the `BUCKET_PARAMETER_NAME` to `/<your-name>/prod/codebuild/WEBSITE_BUCKET_NAME`. This is necessary for the app to work correctly. Push this to your branch.
 
 
 ## Create a policy to get full access to the S3 website bucket
@@ -86,7 +88,7 @@ With [AWS Policies](http://docs.aws.amazon.com/IAM/latest/UserGuide/access_polic
 5. Search and select `AmazonS3FullAccess` (this is a premade policy, but you can also build your own).
 6. Click the **JSON** tab and change the `Resource` value to `["arn:aws:s3:::<your-bucket-name>", "arn:aws:s3:::<your-bucket-name>/*"]` in the JSON content.
 7. Click **Review policy**
-8. Choose a name for the policy (eg. S3WebsiteFullAccess) and click in Create Policy.
+8. Choose a name for the policy (eg. `<YourName>S3WebsiteFullAccess`) and click in Create Policy.
 
 Now we have a policy that allows full access (list, write, update, delete, etc) to our website bucket. Let’s see how we can use it in the following section.
 
@@ -101,7 +103,7 @@ Follow these steps to get it ready:
 
 1. Go to **CodeBuild** under the **Developer Tools** section.
 2. Click on Get Started (or Create Project if you had other projects).
-3. Choose a project name and write a description (optional).
+3. Choose a project name and write a description (optional). A good name is `<your-name>-workshop`.
 4. On the Source section:
     1. Choose **Github** as the source provider.
     2. Select an option for the repository (probably _Public repository_).
@@ -113,7 +115,7 @@ Follow these steps to get it ready:
     2. Select  `aws/codebuild/standard:5.0` as the Image and latest Image Version.
 6. In the Service Role section:
     1. Select New service role.
-    1. Choose a name for the Role and name it `aws-workshop-service-rcodebuild-ole`.
+    1. Choose a name for the Role and name it `<your-name>-aws-workshop-service-rcodebuild-ole`.
 7. In the BuildSpec section:
     1. Choose `Use a Buildspec file`.
     2. Set to name to `buildspec.frontend.yml` (our yaml file with the steps to follow).
@@ -135,7 +137,7 @@ Earlier, we created a policy to allow full access to our S3 bucket and assigned 
 2. Click in Roles.
 3. You should see the role created in the CodeBuild project creation, select it.
 4. Click Attach Policies.
-5. Search for the Policy for full access to the S3 website bucket (`S3WebsiteFullAccess`) and select it.
+5. Search for the Policy for full access to the S3 website bucket (`<YourName>S3WebsiteFullAccess`) and select it.
 6. Click Attach Policy.
 
 **SSM read access**

--- a/workshop/s3-web-ec2-api-rds/01-serve-website-from-s3.md
+++ b/workshop/s3-web-ec2-api-rds/01-serve-website-from-s3.md
@@ -4,32 +4,56 @@
 
 First we need to create a bucket from where we are going to serve the website.
 
-1. On your AWS Console, go to **S3** under **Storage section** and click on Create bucket.
-2. Enter the name of the bucket. Remember, bucket names must be unique across all existing accounts and regions in AWS. You cannot rename a bucket after it is created, so chose the name wisely. Amazon suggests using DNS-compliant bucket names. You should read more about this [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules).
-3. Pick a region for the S3 bucket. You can chose any region you like, but beware that Amazon has [different pricing](https://aws.amazon.com/s3/pricing/) for storage in different regions. In this case (though it won't matter too much) we will pick `US East (N. Virginia)`.
-4. Click Create. We will configure the properties later.
-5. Once created, click on the name of your bucket, go to properties, click **Static website hosting** check the option **Use this bucket to host a website**
-6. As index and error document put: `index.html`. Later, we will go to the **endpoint url** specified at the top to access our website.
-7. Click Save.
-8. Go to **Permissions** tab.
-9. On the **Block public access** section, click **Edit** , uncheck **Block all public access**, save and confirm.
-9. Then go to **Bucket Policy** section and add the following policy to make every object readable:
-  ```
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Sid": "AddPerm",
-              "Effect": "Allow",
-              "Principal": "*",
-              "Action": "s3:GetObject",
-              "Resource": "arn:aws:s3:::<your-bucket-name>/*"
-          }
-      ]
-  }
-  ```
+1. On your AWS Console, go to **S3** under **Storage section**.
+2. Click on Create bucket.
+3. Enter the name of the bucket.
 
-10. Click Save
+    Remember, bucket names must be unique across all existing accounts and regions in AWS. You cannot rename a bucket after it is created, so chose the name wisely. Amazon suggests using DNS-compliant bucket names. You should read more about this [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules).
+
+    A good bucket name is `<your_name>-workshop`.
+
+4. Pick a region for the S3 bucket.
+
+    You can chose any region you like, but beware that Amazon has [different pricing](https://aws.amazon.com/s3/pricing/) for storage in different regions. In this case (though it won't matter too much) we will pick `US East (N. Virginia)`.
+5. Click Create. We will configure the properties later.
+
+## Enable static website hosting
+Once created, enable static website hosting for this bucket by
+1. Clicking on the name of your bucket.
+2. Going to Properties.
+3. Scrolling down to **Static website hosting**.
+4. Clicking the _Edit_ button.
+5. Checking the **Enable** option under **Static website hosting**.
+6. Checking the **Host static website** option under **Hosting Type**.
+6. Putting `index.html` as index and error documents. 
+7. Clicking Save.
+
+Note the URL under **Bucket website endpoint** in the **Static website hosting** section. Later, we will go to the **endpoint url** specified to access our website.
+
+## Enable and configure public access
+Enable public access by going to the **Permissions** tab (you might need to scroll back up from where you are) and:
+1. Click **Edit** on the **Block public access** section.
+2. Uncheck **Block all public access**.
+3. Save and confirm.
+
+Now, still in the **Permissions** tab, make every object readable by
+1. Clicking **Edit** on the **Bucket Policy** section.
+2. Adding the following policy to make every object readable:
+    ```
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AddPerm",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::<your-bucket-name>/*"
+            }
+        ]
+    }
+    ```
+3. Saving.
 
 
 ## Add `WEBSITE_BUCKET_NAME` to the Parameters Store
@@ -38,9 +62,10 @@ Every application needs to have some configurations that inherently will vary be
 
 [AWS Parameters Store](http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html) is a service designed for just this, and we will use it to store variables of our system. This will enable us to store constants and later use them during other steps of the deployment. We will start by storing the bucket name.
 
-1. Go to **S3** under **Storage** **section**.
-2. See details of the bucket you just created and copy its name.
-3. Go to AWS console **Systems Manager** under **Management & Governance**.
+1. Get your bucket's name (the one you created before).
+
+    If you don't remember it, you can find all your buckets if you go to **S3** under **Storage** **section**.
+3. In the search bar  up top, search for **Systems Manager** (it's under **Management & Governance**).
 4. On the left menu select **Parameter Store**.
 5. Click **Create Parameter**.
 6. Enter `/prod/codebuild/WEBSITE_BUCKET_NAME` as name and a meaningful description of what the parameter means (ie. "name of the website bucket").
@@ -65,6 +90,8 @@ With [AWS Policies](http://docs.aws.amazon.com/IAM/latest/UserGuide/access_polic
 
 Now we have a policy that allows full access (list, write, update, delete, etc) to our website bucket. Let’s see how we can use it in the following section.
 
+Don't fret, only a particular _role_ will have this policy attached to it. It's not like _everyone_ will have full access to your S3 bucket (that would be dangerous). More on this later.
+
 
 ## Create a project in CodeBuild to build and deploy the frontend
 
@@ -76,19 +103,22 @@ Follow these steps to get it ready:
 2. Click on Get Started (or Create Project if you had other projects).
 3. Choose a project name and write a description (optional).
 4. On the Source section:
-  1. Choose **Github** as the source provider.
-  2. Select an option for the repository.
-  3. Connect Github with AWS if neccesary.
-  4. Fill the repository URL or choose one repository from your Github account.
+    1. Choose **Github** as the source provider.
+    2. Select an option for the repository (probably _Public repository_).
+    3. Connect Github with AWS if neccesary.
+    4. Fill the repository URL or choose one repository from your Github account.
+    5. Write your branch's name under **Source version**.
 5. On the Environment section:
-  1. Choose Ubuntu as the OS and Standard as the Runtime.
-  2. Select  `aws/codebuild/standard:1.0` as the Image and latest Image Version.
+    1. Choose Ubuntu as the OS and Standard as the Runtime.
+    2. Select  `aws/codebuild/standard:5.0` as the Image and latest Image Version.
 6. In the Service Role section:
-  1. Select New service role.
-  2. Choose a name for the Role and name it `codebuild-aws-workshop-service-role`.
-7. In the BuildSpec section choose `Use a Buildspec file` and below name to `buildspec.frontend.yml` (our yaml file with the steps to follow).
+    1. Select New service role.
+    1. Choose a name for the Role and name it `aws-workshop-service-rcodebuild-ole`.
+7. In the BuildSpec section:
+    1. Choose `Use a Buildspec file`.
+    2. Set to name to `buildspec.frontend.yml` (our yaml file with the steps to follow).
 8. In the Artifacts section select _No artifacts_.
-9. Click on Continue.
+9. Click on Create Build Project.
 10. Click on Save.
 
 Now, we have created a CodeBuild application. We won’t be able to run it though, because we don’t have permissions to add files to our S3 bucket. That is why earlier we created a policy and also something called a "role". For everything to work, we need to attach the policy to the role.
@@ -104,8 +134,9 @@ Earlier, we created a policy to allow full access to our S3 bucket and assigned 
 1. Go to IAM under Security, Identity & Compliance.
 2. Click in Roles.
 3. You should see the role created in the CodeBuild project creation, select it.
-4. Click Attach Policy.
-5. Search for the Policy for full access to the S3 website bucket, select it and then click Attach Policy.
+4. Click Attach Policies.
+5. Search for the Policy for full access to the S3 website bucket (`S3WebsiteFullAccess`) and select it.
+6. Click Attach Policy.
 
 **SSM read access**
 

--- a/workshop/s3-web-ec2-api-rds/02-EC2-instances.md
+++ b/workshop/s3-web-ec2-api-rds/02-EC2-instances.md
@@ -6,7 +6,7 @@ First we will create a role to allow our EC2 instances access to SSM:
 
 1. Go to **IAM** under **Security, Identity & Compliance**.
 2. Go to Role section and click Create Role.
-3. In 'Select type of trusted entity' select **AWS Service**, then **EC2** and click next.
+3. In 'Select type of trusted entity' select **AWS Service**, then **EC2** and click _Next: Permissions_.
 4. Search for `AmazonSSMReadOnlyAccess`, select it and click next.
 5. Lets call it `ApiRole`. Click create Role.
 
@@ -17,9 +17,10 @@ We have already created entries in the Parameter Store. In the future we will ne
 3. Selct symmetric and click next.
 3. Enter `workshopkey` as alias and a meaningful description like "this is the encryption key for the AWS workshop".
 4. Click next step.
-5. Select both your AWS CLI and console users and click next.
-6. Select your EC2 Role and click next.
-7. Click Finish.
+5. Select both your AWS CLI and console users as key administrators. If you are using your Tryo Playground account, it's just 1 user that can do both.
+6. Click next.
+7. Select your EC2 Role (`ApiRole`) and click next.
+8. Click Finish.
 
 In the future, if an EC2 instance with our new role wants to access an encrypted parameter, AWS will automatically decrypt it!
 
@@ -27,39 +28,51 @@ In the future, if an EC2 instance with our new role wants to access an encrypted
 
 We are ready to launch our first EC2 instance. We will create a standard EC2 instance, add a [startup script](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) (which will run automatically when the instance boots) and finally create a [security group](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html) that will control the outbound and inbound in our EC2 instances.
 
-1. Go to the **EC2** under **Compute section**, and in the top right corner, you can pick the region we are going to use. In this case, we will be using the same region that we used for the S3 bucket setup earlier, that is, `US East (N. Virginia)`.
+1. Go to **EC2** under **Compute section**.
+
+    In the top right corner, you can pick the region we are going to use. In this case, we will be using the same region that we used for the S3 bucket setup earlier, that is, `US East (N. Virginia)`.
+2. Click on _Instances_ in the left panel.
 2. Click on Launch Instance.
 3. Look for Ubuntu Server (make sure it is Free tier eligible) and click Select.
-4. Select `t2.micro` and then click on Next: Configure Instance Details.
-5. Select our `ApiRole` on **IAM role**.
-6. On Advanced Details, select "As text" in User data and then paste the following bash script:
-    ```
-    #!/bin/bash
-    export LC_ALL=C.UTF-8
-    apt update
-    apt -y install ruby
-    cd /home/ubuntu
-    wget https://aws-codedeploy-us-east-1.s3.amazonaws.com/latest/install
-    chmod +x ./install
-    ./install auto
-    ```
+4. Select `t2.micro`.
+5. Click on Next: Configure Instance Details. Configure the following:
 
-    Be careful, if you leave spaces at the beginning of the script it will not work. So NO SPACES!
-    If you are using another region, the bucket name in the `wget` line needs to be modified (see [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/resource-kit.html#resource-kit-bucket-names)).
+    1. Select our `ApiRole` on **IAM role**.
+    2. On Advanced Details, select "As text" in User data and then paste the following bash script:
+        ```
+        #!/bin/bash
+        export LC_ALL=C.UTF-8
+        apt update
+        apt -y install ruby
+        cd /home/ubuntu
+        wget https://aws-codedeploy-us-east-1.s3.amazonaws.com/latest/install
+        chmod +x ./install
+        ./install auto
+        ```
 
-7. Click Next: Add Storage.
-8. Leave the default settings and click Next: Add Tags.
-9. Click Add Tag.
-10. Fill Key with `service` and in Value with `api`.
-11. Add another tag with Key `environment` and Value `prod`. These keys will help us identify our EC2 instances running the API later.
-12. Click on Next: Configure Security Group.
-13. Make sure the _Create a new security group_ option is selected and write a descriptive name on the _Security group name:_ field. You cannot rename it later so choose the name wisely.
-14. Click Add Rule.
-15. In port range put `9000` and in Source `0.0.0.0/0`, and add a meaningful description. This will enable incoming traffic on port 9000 from every IP, so you can "contact" your instance from the outside. If you pay attention, by default we also get a rule allowing inbound traffic on port 22, which we will use for SSH'ing to the instance. Also by default, outbound traffic (that is, traffic originating from your instance) will be allowed to any destination and port, but you can restrict that later by editing the outbound rules for the security group.
-16. Click Review and Launch.
-17. Click Launch.
-18. When asked to select an existing key pair, choose `create a new key pair`, name it `aws_workshop` and click download. Store it in a secure place (`~/.ssh` is good, but make sure you `chmod 400` the PEM file so only your user can read it), we will use it to SSH into the instances during the whole workshop.
-19. Click Launch Instances.
+        Be careful, if you leave spaces at the beginning of the script it will not work. So NO SPACES!
+        If you are using another region, the bucket name in the `wget` line needs to be modified (see [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/resource-kit.html#resource-kit-bucket-names)).
+6. Click Next: Add Storage.
+    1. Leave the default settings
+7. Click Next: Add Tags. These keys will help us identify our EC2 instances running the API later.
+    1. Click Add Tag.
+    2. Fill Key with `service` and Value with `api`.
+    3. Add another tag with Key `environment` and Value `prod`.
+8.  Click on Next: Configure Security Group.
+    1. Make sure the _Create a new security group_ option is selected.
+    2. Write a descriptive name on the _Security group name:_ field. You cannot rename it later so choose the name wisely. A good name is `<your-name>-workshop-ec2-security-group`.
+    3. Click Add Rule.
+    4. In port range put `9000` and in Source `0.0.0.0/0`, and add a meaningful description. 
+    
+        This will enable incoming traffic on port 9000 from every IP, so you can "contact" your instance from the outside.
+        
+        If you pay attention, by default we also get a rule allowing inbound traffic on port 22, which we will use for SSH'ing to the instance.
+        
+        Also by default, outbound traffic (that is, traffic originating from your instance) will be allowed to any destination and port, but you can restrict that later by editing the outbound rules for the security group.
+9.  Click Review and Launch.
+10. Click Launch.
+11. When asked to select an existing key pair, choose `create a new key pair`, name it `aws_workshop` and click download. Store it in a secure place (`~/.ssh` is good, but make sure you `chmod 400` the PEM file so only your user can read it), we will use it to SSH into the instances during the whole workshop.
+12. Click Launch Instances.
 
 ## Add Security Group inbound rule
 1. Go to **Security Groups** under **Network & Security** (still on EC2 service).

--- a/workshop/s3-web-ec2-api-rds/02-EC2-instances.md
+++ b/workshop/s3-web-ec2-api-rds/02-EC2-instances.md
@@ -8,18 +8,19 @@ First we will create a role to allow our EC2 instances access to SSM:
 2. Go to Role section and click Create Role.
 3. In 'Select type of trusted entity' select **AWS Service**, then **EC2** and click _Next: Permissions_.
 4. Search for `AmazonSSMReadOnlyAccess`, select it and click next.
-5. Lets call it `ApiRole`. Click create Role.
+5. Lets call it `<YourName>ApiRole`. 
+6. Click create Role.
 
 We have already created entries in the Parameter Store. In the future we will need encrypted variables, like the password for our database. For this, will create an encryption key to encrypt and decrypt those values. That encryption key will be attached to our admin user and to the role we just created, so only services that are setup to assume the role can get access to the decrypted values. You can read more about SSM and secure data [here](https://aws.amazon.com/blogs/compute/managing-secrets-for-amazon-ecs-applications-using-parameter-store-and-iam-roles-for-tasks/).
 
 1. Go to **Key Management Service (KMS)** under **Security, Identity & Compliance**.
 2. Select **Create key**.
 3. Selct symmetric and click next.
-3. Enter `workshopkey` as alias and a meaningful description like "this is the encryption key for the AWS workshop".
+3. Enter `<your-name>-workshopkey` as alias and a meaningful description like "this is the encryption key for the AWS workshop".
 4. Click next step.
 5. Select both your AWS CLI and console users as key administrators. If you are using your Tryo Playground account, it's just 1 user that can do both.
 6. Click next.
-7. Select your EC2 Role (`ApiRole`) and click next.
+7. Select your EC2 Role (`<YourRole>ApiRole`) and click next.
 8. Click Finish.
 
 In the future, if an EC2 instance with our new role wants to access an encrypted parameter, AWS will automatically decrypt it!
@@ -37,7 +38,7 @@ We are ready to launch our first EC2 instance. We will create a standard EC2 ins
 4. Select `t2.micro`.
 5. Click on Next: Configure Instance Details. Configure the following:
 
-    1. Select our `ApiRole` on **IAM role**.
+    1. Select our `<YourRole>ApiRole` on **IAM role**.
     2. On Advanced Details, select "As text" in User data and then paste the following bash script:
         ```
         #!/bin/bash
@@ -69,14 +70,14 @@ We are ready to launch our first EC2 instance. We will create a standard EC2 ins
         If you pay attention, by default we also get a rule allowing inbound traffic on port 22, which we will use for SSH'ing to the instance.
         
         Also by default, outbound traffic (that is, traffic originating from your instance) will be allowed to any destination and port, but you can restrict that later by editing the outbound rules for the security group.
-9.  Click Review and Launch.
-10. Click Launch.
-11. When asked to select an existing key pair, choose `create a new key pair`, name it `aws_workshop` and click download. Store it in a secure place (`~/.ssh` is good, but make sure you `chmod 400` the PEM file so only your user can read it), we will use it to SSH into the instances during the whole workshop.
-12. Click Launch Instances.
+16. Click Review and Launch.
+17. Click Launch.
+18. When asked to select an existing key pair, choose `create a new key pair`, name it `<your_name>_aws_workshop` and click download. Store it in a secure place (`~/.ssh` is good, but make sure you `chmod 400` the PEM file so only your user can read it), we will use it to SSH into the instances during the whole workshop.
+19. Click Launch Instances.
 
 ## Add Security Group inbound rule
 1. Go to **Security Groups** under **Network & Security** (still on EC2 service).
-2. Open the Security Group you created when launching the EC2 (step 13).
+2. Open the Security Group you created when launching the EC2 (`<your-name>-workshop-ec2-security-group`).
 3. Click **Edit inbound rules**.
 4. Add a new rule with type `PostgreSQL` (port `5432` should be set automatically). As source select the security group itself (start typing the name and select the one suggested). Note that this rule could not be added on the previous step because the security group didn't exist at that point.
 5. Click **Save rules**.

--- a/workshop/s3-web-ec2-api-rds/03-RDS.md
+++ b/workshop/s3-web-ec2-api-rds/03-RDS.md
@@ -32,15 +32,17 @@ As before, we will need some variables stored in the parameter store, including 
 4. Go to AWS console **Systems Manager** under **Management & Governance**.
 5. On the left menu select **Parameter Store**.
 6. Click Create Parameter.
-7. Enter  `/prod/api/DATABASE_NAME` as the name and a meaningful description like "Name of the PostgreSQL database".
+7. Enter  `/<your-name>/prod/api/DATABASE_NAME` as the name and a meaningful description like "Name of the PostgreSQL database".
 8. Enter the DB name you selected before on the value attribute.
 9. Click create parameter and close.
 10. Now we will need to do the same thing for the username and host
-  1. For the username enter `/prod/api/DATABASE_USER` as the name and your database username and as the value
-  2. For the host enter `/prod/api/DATABASE_HOST` as the name and the hostname you copied earlier as the value
-11. For `/prod/api/DATABASE_PASSWORD` do the same steps but select as **Type: Secure String** and as KMS Key ID the key `workshopkey`.
+  1. For the username enter `/<your-name>/prod/api/DATABASE_USER` as the name and your database username and as the value
+  2. For the host enter `/<your-name>/prod/api/DATABASE_HOST` as the name and the **Endpoint** you copied earlier as the value
+11. For `/<your-name>/prod/api/DATABASE_PASSWORD` do the same steps but select as **Type: Secure String** and as KMS Key ID the key `<your-name>-workshopkey`.
 
 Now we have our database parameters set, and the password encrypted. Only our EC2 instances will be able to decrypt it.
+
+You should _now_ go to [ec2.py](/backend/conduit/settings/ec2.py) and change the `PARAMETERS_PATH` to `/<your-name>/prod/api./`. This is necessary for the app to work correctly. Push this to your branch.
 
 ---
 **Extra mile:**

--- a/workshop/s3-web-ec2-api-rds/03-RDS.md
+++ b/workshop/s3-web-ec2-api-rds/03-RDS.md
@@ -42,7 +42,7 @@ As before, we will need some variables stored in the parameter store, including 
 
 Now we have our database parameters set, and the password encrypted. Only our EC2 instances will be able to decrypt it.
 
-You should _now_ go to [ec2.py](/backend/conduit/settings/ec2.py) and change the `PARAMETERS_PATH` to `/<your-name>/prod/api./`. This is necessary for the app to work correctly. Push this to your branch.
+You should _now_ go to [ec2.py](/backend/conduit/settings/ec2.py) and change the `PARAMETERS_PATH` to `/<your-name>/prod/api./`. While you are at it, you should also visit [lambda_function.py](/infrastructure/aws/lambda/lambda_function.py) and prefix the `Name` in `db_host`, `db_name`, `db_user` and `db_pass` with `/<your-name>/` as well. This is necessary for the app to work correctly. Push this to your branch.
 
 ---
 **Extra mile:**

--- a/workshop/s3-web-ec2-api-rds/03-RDS.md
+++ b/workshop/s3-web-ec2-api-rds/03-RDS.md
@@ -3,12 +3,20 @@
 ## Create a PostgreSQL instance in RDS
 1. Go to **RDS** under **Database** section.
 2. Click on **Create Database**.
-3. Click on PostgreSQL logo, and under **Templates** section tick the _"Free Tier"_ checkbox.
-4. Enter a name on _DB Instance identifier_ (we will need it later, so don’t forget it).
-5. Enter a username and password and click Next (again, we will need these later).
-6. Under **Connectivity** section verify that **Publicly Accessible** is set to No.
-7. On **VPC security groups** choose _Select existing VPC security groups_ and select the security group you created when [launching the EC2 instance](/workshop/s3-web-ec2-api-rds/02-EC2-instances.md#launch-your-first-ec2-instance).
-8. Pick a db name under **Additional Configuration** and click create Database (again, we will need the database name later).
+3. Select the engine by:
+    1. Clicking on PostgreSQL logo.
+    2. Choosing a _Version_ with version major 12 (i.e.: PostgreSQL 12.8-R1).
+        
+        At the time of writing, PostgreSQL 13 is not included in the free tier but 12 is.
+4. Under **Templates** section tick the _"Free Tier"_ checkbox.
+5. Enter a name on _DB Instance identifier_ (we will need it later, so don’t forget it).
+6. Enter a username and password and click Next (again, we will need these later). Save these in your password manager.
+7. Under the **Connectivity** section:
+    1. Verify that **Public Access** is set to No.
+    2. On **VPC security groups** choose _Select existing VPC security groups_.
+    3. Select the security group you created when [launching the EC2 instance](/workshop/s3-web-ec2-api-rds/02-EC2-instances.md#launch-your-first-ec2-instance). If you followed the naming recommendation, this name should be `<your-name>-workshop-ec2-security-group`.
+8. Pick an _Initial database name_ under **Additional Configuration** (again, we will need the database name later).
+9. Click create Database.
 
 Now our instance is created. We configured its access, allowing every instance under the security group that was created in the previous section to connect.
 
@@ -18,7 +26,9 @@ As before, we will need some variables stored in the parameter store, including 
 
 1. Go to **RDS** under **Database** section.
 2. Click on Instances.
-3. Wait for instance to create. Then see details of your db and copy the **Endpoint**. This will be the value for `DATABASE_HOST`.
+3. Wait for the instance to get created. 
+4. Once done, click the name.
+    1. Copy the **Endpoint**. This will be the value for `DATABASE_HOST`.
 4. Go to AWS console **Systems Manager** under **Management & Governance**.
 5. On the left menu select **Parameter Store**.
 6. Click Create Parameter.

--- a/workshop/s3-web-ec2-api-rds/04-code-deploy.md
+++ b/workshop/s3-web-ec2-api-rds/04-code-deploy.md
@@ -1,31 +1,47 @@
 # CodeDeploy
 
-[CodeBuild](http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html) is a service to automate the deployment of any kind of applications to EC2 instances. The configuration is really simple and easy to adapt. The deployment process is described in an `appspec.yml` file like [this one](/appspec.yml). If you want to know what happens during the deploy, you can also check the implementation of the hooks [here](/infrastructure/aws/codedeploy).
+[CodeDeploy](http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html) is a service to automate the deployment of any kind of applications to EC2 instances. The configuration is really simple and easy to adapt. The deployment process is described in an `appspec.yml` file like [this one](/appspec.yml). If you want to know what happens during the deploy, you can also check the implementation of the hooks [here](/infrastructure/aws/codedeploy).
 
 First, we need to create a default role for CodeDeploy so it can have access to other AWS services (like S3).
 
 ## Create CodeDeploy Role
 1. Go to **IAM** under **Security, Identity & Compliance**.
 2. Go to **Role** section and click **Create Role**.
-3. Select **CodeDeploy** for both service and use case and click **Next: Permissions**.
-4. Select **Next: Tags**.
-5. Select **Next: Review**.
-6. Type a name and description and click **Create Role**.
+3. Select **AWS Service** up top.
+4. Select **CodeDeploy** from the **Chose a use case** list.
+5. Select **CodeDeploy** from the **Select your use case** section that just appeared.
+6. Click **Next: Permissions**.
+7. Select **Next: Tags**.
+8. Select **Next: Review**.
+9. Type a name and description. A good name is `<YourName>CodeDeploy`.
+10. Click **Create Role**.
 
 Now we are ready to start using it.
 
 ##  Configure Code Deploy
+First, let's create an application.
 1. Go to **CodeDeploy** under **Developer Tools**.
 2. Go to **Applications** and click **Create application**.
-3. Enter an **Application name** and **EC2/On-premises** on **Compute platform** then click **Create Application**.
-4. Click on **Create Deployment group** and enter a Deployment Group name.
-5. On **Service role** select the role created to grant CodeDeploy access to the instances.
-6. Select **In-place** on **Deployment Type** section.
-7. Check **Amazon EC2 instances** in **Environment Configuration**, then on the first tag group select `environment` as Key and as Value `prod`, on the second line select `service` as Key and as Value `api`. This means that CodeDeploy will deploy our application to all the EC2 instances with those tags.
-8. On **Deployment settings** select **CodeDeployDefault.OneAtATime** in Deployment Configurations.
-9. Under **Load Balancer** uncheck **Enable load balancing**
-10. Click **Create deployment group**
+   1. Enter an **Application name**. A good name is `<your-name>-workshop`.
+   2. On **Compute platform** select **EC2/On-premises**.
+3. Click **Create Application**.
 
+An application can have many kinds of deployments (think _production_, _development_ and _staging_). To configure each one, we will create _deployment groups_. Once inside the application:
+1. Click on **Create Deployment group**.
+2. Enter a Deployment Group name. In this case we won't distinguish between _prod_ or _dev_, so just name it `<your-name>-workshop-deployment-group`.
+3. On **Service role** select the role created to grant CodeDeploy access to the instances (probably `CodeDeploy`).
+4. Select **In-place** on **Deployment Type** section.
+5. In **Environment Configuration**:
+   1. Check **Amazon EC2 instances**.
+   2. Add a tag with `environment` as Key and as Value `prod`.
+   3. Add a tag with `service` as Key and as Value `api`.
+
+    This will ensure CodeDeploy deploys the API only to the EC2 instances that are tagged with these exact tags. This is where you would chose the instances used for _prod_ or _dev_.
+6. On **Deployment settings** select **CodeDeployDefault.OneAtATime** in Deployment Configurations.
+7. Under **Load Balancer** uncheck **Enable load balancing**
+8. Click **Create deployment group**
+
+## Deploy
 Now our CodeDeploy application is ready. Let’s try our first deployment.
 
 1. On the deployment group details of the group we just made, click **Create Deployment**
@@ -33,11 +49,11 @@ Now our CodeDeploy application is ready. Let’s try our first deployment.
 3. In **Connect to GitHub** section type your GitHub account and select **Connect to GitHub**.
 4. Allow AWS to access your GitHub account, if needed.
 5. Enter your repository name in the form _account/repository_.
-6. In **Commit ID** type the commit hash that you want to deploy.
+6. In **Commit ID** type the commit hash that you want to deploy. This will be from the latest commit of your branch (with the fixes to the parameter paths done).
 7. Select **Overwrite the content** below.
 8. Click **Create Deployment**.
 
-During the deploy try **View instances** and then **View events** to follow the progress and see what's happening.
+This should leave you inside the deployment page. During the deploy try clicking **View events** next each instance in the **Deployment lifecycle events** table to follow the progress and see what's happening.
 
 ---
 **Extra mile:** once the deploy finishes:

--- a/workshop/s3-web-ec2-api-rds/04-code-deploy.md
+++ b/workshop/s3-web-ec2-api-rds/04-code-deploy.md
@@ -29,7 +29,7 @@ First, let's create an application.
 An application can have many kinds of deployments (think _production_, _development_ and _staging_). To configure each one, we will create _deployment groups_. Once inside the application:
 1. Click on **Create Deployment group**.
 2. Enter a Deployment Group name. In this case we won't distinguish between _prod_ or _dev_, so just name it `<your-name>-workshop-deployment-group`.
-3. On **Service role** select the role created to grant CodeDeploy access to the instances (probably `CodeDeploy`).
+3. On **Service role** select the role created to grant CodeDeploy access to the instances (probably `<YourName>CodeDeploy`).
 4. Select **In-place** on **Deployment Type** section.
 5. In **Environment Configuration**:
    1. Check **Amazon EC2 instances**.

--- a/workshop/s3-web-ec2-api-rds/04-code-deploy.md
+++ b/workshop/s3-web-ec2-api-rds/04-code-deploy.md
@@ -41,6 +41,16 @@ An application can have many kinds of deployments (think _production_, _developm
 7. Under **Load Balancer** uncheck **Enable load balancing**
 8. Click **Create deployment group**
 
+You can get the deployment group's ID (for access to logs) by running
+```
+aws deploy get-deployment-group \
+    --application-name <your-name>-workshop \
+    --deployment-group-name <your-name>-workshop-deployment-group \
+```
+in your computer's console and looking for the key `deploymentGroupId` in the output.
+
+You might need to add a `--profile` flag if you set up `aws` for this workshop with a profile other than `default`.
+
 ## Deploy
 Now our CodeDeploy application is ready. Let’s try our first deployment.
 
@@ -54,6 +64,8 @@ Now our CodeDeploy application is ready. Let’s try our first deployment.
 8. Click **Create Deployment**.
 
 This should leave you inside the deployment page. During the deploy try clicking **View events** next each instance in the **Deployment lifecycle events** table to follow the progress and see what's happening.
+
+Up top you'll see a string like `d-<CHARACTERS>`. That's the deploy ID that you need to access logs in the instance.
 
 ## Re deploying
 You might need to re deploy the project. Just in case, this is how it's done:

--- a/workshop/s3-web-ec2-api-rds/04-code-deploy.md
+++ b/workshop/s3-web-ec2-api-rds/04-code-deploy.md
@@ -55,6 +55,19 @@ Now our CodeDeploy application is ready. Let’s try our first deployment.
 
 This should leave you inside the deployment page. During the deploy try clicking **View events** next each instance in the **Deployment lifecycle events** table to follow the progress and see what's happening.
 
+## Re deploying
+You might need to re deploy the project. Just in case, this is how it's done:
+
+1. Go to **CodeDeploy**.
+2. Go to **Applications**.
+3. Click your application.
+4. Click your deploment group.
+5. You can either create a new deployment from scratch or re use an old one.
+   1. If creating one from scratch, follow the steps in the previous section.
+   2. If re using a deployment, select it and click _Create Deploment_ **after** either:
+      - Clicking **Retry deployment** to retry that exact deployment.
+      - Clicking **Copy deployment** to get a configuration screen with most details from the selected deployment carried over and changing the Commit ID and click **One at a time** (and change any other settings you need to).
+
 ---
 **Extra mile:** once the deploy finishes:
 

--- a/workshop/s3-web-ec2-api-rds/05-finishing-up.md
+++ b/workshop/s3-web-ec2-api-rds/05-finishing-up.md
@@ -6,7 +6,7 @@ We are almost done. We have to add some more parameters and we are ready to depl
 1. Go to **EC2** under **Compute** section.
 2. Select your instance.
 3. Copy the **Public DNS** under **Description**.
-4. On the left menu select **Parameter Store**.
+4. Go to the **Parameter Store** under Systems Manager.
 5. Click **Create Parameter**.
 6. Enter  `/prod/frontend/API_URL` as name and `http://<public dns you copied>:9000` as value.
 7. Click **Create Parameter** and close.
@@ -15,13 +15,15 @@ This will be used by CodeBuild, so the frontend knows where the API is. You can 
 
 ## Run CodeBuild project
 1. Go to **CodeBuild** under the **Developer Tools** section.
-2. Select the project created before and click **Start Build**.
+2. Select the project created before.
 3. Click **Start Build**.
 4. Wait.
 5. Check if all the phases run successfully.
 6. Done.
 
 Now, if you go to the public URL provided by S3 (under **S3**, your bucket, **Properties**, **Static website hosting**) you will find the endpoint. If everything went as planned, you should see the complete website.
+
+Remember that the page isn't fully functional. But if you cannot hit the API using Postman, you should try re-deploying with the _latest_ commit ID and re building the project.
 
 ---
 **Next:** add an extra [EC2 instance with ELB and auto-scaling](/workshop/elb-auto-scaling-group/introduction.md).

--- a/workshop/s3-web-ec2-api-rds/05-finishing-up.md
+++ b/workshop/s3-web-ec2-api-rds/05-finishing-up.md
@@ -8,10 +8,12 @@ We are almost done. We have to add some more parameters and we are ready to depl
 3. Copy the **Public DNS** under **Description**.
 4. Go to the **Parameter Store** under Systems Manager.
 5. Click **Create Parameter**.
-6. Enter  `/prod/frontend/API_URL` as name and `http://<public dns you copied>:9000` as value.
+6. Enter  `/<your-name>/prod/frontend/API_URL` as name and `http://<public dns you copied>:9000` as value.
 7. Click **Create Parameter** and close.
 
 This will be used by CodeBuild, so the frontend knows where the API is. You can check how [here](/buildspec.frontend.yml).
+
+You should _now_ go to [buildspec.frontend.yml](/buildspec.frontend.yml) and change the `API_URL_PARAMETER_NAME` to `/<your-name>/prod/frontend/API_URL`. This is necessary for the app to work correctly. Push this to your branch.
 
 ## Run CodeBuild project
 1. Go to **CodeBuild** under the **Developer Tools** section.

--- a/workshop/s3-web-ec2-api-rds/introduction.md
+++ b/workshop/s3-web-ec2-api-rds/introduction.md
@@ -36,6 +36,15 @@ From this menu you can _favourite_ services, which will make accessing them much
 ## Repository
 You will probably have to make some changes in the code, so you should create a new branch you can push for your modifications.
 
+## Getting logs from EC2 instances
+We will configure EC2 instances with a security policy that allows `ssh` access to the instances. You can view logs by `ssh`ing to the instance or by using `scp`.
+
+You can view logs of _all_ deployments in the instance's `/opt/codedeploy-agent/deployment-root/deployment-logs/codedeploy-agent-deployments.log`.
+
+You can also view logs of a specific deployment in the instance's `/opt/codedeploy-agent/deployment-root/<deployment-group-ID>/<deployment-ID>/logs/scripts.log`. You will learn how to find these parameters later.
+
+More on logging [here](https://docs.aws.amazon.com/codedeploy/latest/userguide/deployments-view-logs.html#deployments-view-logs-instance-unix).
+
 ## Summary
 To sum up, in this section we will create:
 

--- a/workshop/s3-web-ec2-api-rds/introduction.md
+++ b/workshop/s3-web-ec2-api-rds/introduction.md
@@ -18,6 +18,25 @@ The API endpoints are described in detail [here](https://github.com/ahmed-belhad
 ## Database
 Last but not least our database will be hosted using [AWS RDS](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html), as a PostgreSQL instance.
 
+## AWS Console
+Get familiar with the AWS Console (the web interface [here](https://console.aws.amazon.com)), it's what you'll mostly use throughout the workshop.
+
+In particular, note that there's a search bar up top. Whenever the workshop instructs you to go somewhere, start by looking it up in that search bar.
+
+Next to the search bar there's a `Services` button, which shows a menu with all of AWS's offerings. Whenever a new service is introduced by the workshop, the instructions will reference a section under this `Services` menu. For example: `Compute/EC2`. 
+
+From this menu you can _favourite_ services, which will make accessing them much faster. You can't favourite services from a search result. As part of your exploration, you could try favouriting the following services:
+- EC2 under Compute.
+- S3 under Storage.
+- Systems Manager under Management & Governance.
+- Code Build under Developer Tools.
+- RDS under Database.
+- IAM under Security, Indentity & Compliance.
+
+## Repository
+You will probably have to make some changes in the code, so you should create a new branch you can push for your modifications.
+
+## Summary
 To sum up, in this section we will create:
 
 - an S3 bucket to host our static frontend.

--- a/workshop/s3-web-ec2-api-rds/introduction.md
+++ b/workshop/s3-web-ec2-api-rds/introduction.md
@@ -47,6 +47,9 @@ To sum up, in this section we will create:
 > **Important:** after you are done with this workshop, you will ideally clean up your account, so you are not billed anymore. This means that you need to delete everything you have created.
 >
 > Many resources in AWS [can be tagged](https://aws.amazon.com/answers/account-management/aws-tagging-strategies/). If something can be tagged, then you should tag it with a **unique name**. Later, you can use the [Tag Editor](https://aws.amazon.com/blogs/aws/resource-groups-and-tagging/) to find your tagged resources to delete, and make sure you don't leave anything behind.
+>
+> A good tag/value pair to use is `<your_name>-workshop`/`True`. Whatever you chose, be consistent so that it's easy to clean up your account.
+
 
 ---
 

--- a/workshop/s3-web-ec2-api-rds/introduction.md
+++ b/workshop/s3-web-ec2-api-rds/introduction.md
@@ -2,13 +2,20 @@
 
 We are ready to start the deployment of our website.
 
+## Frontend
 The first step will be the frontend. Because it’s a static website, we can create an [S3 bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html), put all the code in it and serve it as a static website. Think of an S3 bucket as a folder in the cloud, which can be setup for access from the outside world via a URL (and even help a bit with your application's routes).
 
-To automate the build, we will use [CodeBuild](https://aws.amazon.com/codebuild/), AWS service to build projects on the go.
+To automate the build, we will use [CodeBuild](https://aws.amazon.com/codebuild/), an AWS service to build projects on the go.
 CodeBuild will pull our repository, build the webpage and copy the build directory to S3. The configuration is specified on `buildspec.frontend.yml` on [the root folder of our repo](/buildspec.frontend.yml).
 
 In order to automate the deployment of our API to the EC2 instances, we will use [CodeDeploy](http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html). It will pull our repo to the EC2 instances and start our server (gunicorn). The full deploy process is described in the `appspec.yml` file, [here](/appspec.yml).
 
+## API
+The API will be deployed to EC2 instances. In order to automate the deployment, we will use [CodeDeploy](http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html). It will pull our repo to the EC2 instances and start our server (gunicorn). The full deploy process is described in the `appspec.yml` file, [here](/appspec.yml).
+
+The API endpoints are described in detail [here](https://github.com/ahmed-belhadj/conduit-node-api/tree/master/api#endpoints).
+
+## Database
 Last but not least our database will be hosted using [AWS RDS](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html), as a PostgreSQL instance.
 
 To sum up, in this section we will create:
@@ -16,7 +23,7 @@ To sum up, in this section we will create:
 - an S3 bucket to host our static frontend.
 - a CodeBuild setup to build the frontend and copy the output to the S3 bucket.
 - a CodeDeploy setup to deploy our API to the EC2 instances.
-- a RDS PostgreSQL instance.
+- an RDS PostgreSQL instance.
 
 > **Important:** after you are done with this workshop, you will ideally clean up your account, so you are not billed anymore. This means that you need to delete everything you have created.
 >

--- a/workshop/s3-web-ec2-api-rds/introduction.md
+++ b/workshop/s3-web-ec2-api-rds/introduction.md
@@ -8,7 +8,7 @@ The first step will be the frontend. Because it’s a static website, we can cre
 To automate the build, we will use [CodeBuild](https://aws.amazon.com/codebuild/), an AWS service to build projects on the go.
 CodeBuild will pull our repository, build the webpage and copy the build directory to S3. The configuration is specified on `buildspec.frontend.yml` on [the root folder of our repo](/buildspec.frontend.yml).
 
-In order to automate the deployment of our API to the EC2 instances, we will use [CodeDeploy](http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html). It will pull our repo to the EC2 instances and start our server (gunicorn). The full deploy process is described in the `appspec.yml` file, [here](/appspec.yml).
+Bare in mind that the frontend isn't complete. This means that while you will be able to navigate it, none of the actions you take will have effect on the back end. For example, signing up or in doesn't currently work. However, hitting the API endpoints for signing up or in _does_ work. This is a problem with the frontend alone, so the concepts related to `aws` still apply.
 
 ## API
 The API will be deployed to EC2 instances. In order to automate the deployment, we will use [CodeDeploy](http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html). It will pull our repo to the EC2 instances and start our server (gunicorn). The full deploy process is described in the `appspec.yml` file, [here](/appspec.yml).

--- a/workshop/set-up-users.md
+++ b/workshop/set-up-users.md
@@ -37,7 +37,9 @@ After this, we can create the user to access AWS programmatically:
 4. Search for: `AdministratorAccess`, check it and click next. Of course, in a real use case, you would design or use a policy with more restricted access.
 5. Click on Download CSV.
 
-In the downloaded file, you can find the access key id and the secret access key. You’ll need them to [configure your AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) in your computer. If you don’t have AWS CLI installed yet, you can do it following [these steps](http://docs.aws.amazon.com/cli/latest/userguide/installing.html).
+In the downloaded file, you can find the access key id and the secret access key. You’ll need them to [configure your AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) in your computer (read the _Quick Setup_ section). If you don’t have AWS CLI installed yet, you can do it following [these steps](http://docs.aws.amazon.com/cli/latest/userguide/installing.html).
+
+By default, the `aws` command uses a `default` profile. If you want, you can have multiple [named profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html).
 
 ---
 **Extra mile**: set the `ViewOnlyAccess` permissions to the user with programmatic access. Double points if you do it with the CLI.

--- a/workshop/set-up-users.md
+++ b/workshop/set-up-users.md
@@ -4,7 +4,7 @@ You will generate (or receive) credentials during this step. You should save the
 
 > **TryoTip:** if you are using the **Tryolabs Playground AWS account**, this section does not apply. Please, read it anyway, so you have some context on what you would do with a bare new AWS account.
 
-As you might already now there is a special account in AWS called _root_. This is the account used to do the initial setup for users, roles and billing information. Is recommended to create a user with administrator privileges for the every day use and [not use the root account](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users) to login to AWS. Additionally, you should make sure you enable [Multi Factor Authentication (MFA)](http://docs.aws.amazon.com/console/iam/security-status-activate-mfa) on your root account, and use an app like [Authy](https://authy.com/) as a second factor on your phone (Android/iOS).
+As you might already know there is a special account in AWS called _root_. This is the account used to do the initial setup for users, roles and billing information. It is recommended to create a user with administrator privileges for every day use and to [not use the root account](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users) to login to AWS. Additionally, you should make sure you enable [Multi Factor Authentication (MFA)](http://docs.aws.amazon.com/console/iam/security-status-activate-mfa) on your root account, and use an app like [Authy](https://authy.com/) as a second factor on your phone (Android/iOS).
 
 Next, we are going to use our root account to setup 2 AWS users.
 

--- a/workshop/set-up-users.md
+++ b/workshop/set-up-users.md
@@ -1,5 +1,7 @@
 # Set up users on AWS
 
+You will generate (or receive) credentials during this step. You should save these credentials in your password manager of choice. If you don't use one yet, take a look at [BitWarden](https://bitwarden.com/): a fully featured and open source password manager.
+
 > **TryoTip:** if you are using the **Tryolabs Playground AWS account**, this section does not apply. Please, read it anyway, so you have some context on what you would do with a bare new AWS account.
 
 As you might already now there is a special account in AWS called _root_. This is the account used to do the initial setup for users, roles and billing information. Is recommended to create a user with administrator privileges for the every day use and [not use the root account](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#create-iam-users) to login to AWS. Additionally, you should make sure you enable [Multi Factor Authentication (MFA)](http://docs.aws.amazon.com/console/iam/security-status-activate-mfa) on your root account, and use an app like [Authy](https://authy.com/) as a second factor on your phone (Android/iOS).


### PR DESCRIPTION
Closes #20.

Most of the changes in this PR are rephrasing and reordering lists, that's why there are so many additions and deletions.

Important changes follow:
**set-up-users:**
1. Recommend a password manager in `set-up-users`.

**Introduction:**
1. Clarify that the frontend isn't fully functional.
2. Add basic explanation on how to navigate AWS's console.
3. Add suggestion to branch `master` before starting, as the user will be committing some things.
4. Explain how to get logs from EC2 instances.

**General:**
Parameters for the parameter store currently have a static name. For an external user, this is not a problem. For people using Tryolabs' playground account this is a problem because using a unique parameter name prevents multiple users from doing the workshop at the same time and could cause issues with old parameters.

Therefore, all parameter naming suggestions have been changed to make them unique to each user. Notes have been made in all files where `/prod/` parameters are referenced to instruct the user to change relevant files and to be consistent.


 